### PR TITLE
Force loose folder deletion

### DIFF
--- a/ModioModNetworker/ModFileManager.cs
+++ b/ModioModNetworker/ModFileManager.cs
@@ -104,7 +104,7 @@ namespace ModioModNetworker
             // Delete the zip
             File.Delete(downloadPath);
             // Delete loose folder
-            Directory.Delete(exportDirectory);
+            Directory.Delete(exportDirectory, true);
             MainClass.warehouseReloadRequested = true;
             MainClass.warehouseTargetFolder = modFolderDestination;
             MainClass.refreshInstalledModsRequested = true;


### PR DESCRIPTION
I made a typo in the commit message :(

Allow the mod to delete the loose folder, even if there are items inside. This should fix mods which have optional code mods bundled with them, and some other weird edge case I think.

In my testing, this change fixed these mods:
~[Patented Force Application Device | QUEST FIX](https://mod.io/g/bonelab/m/baba-corp-patented-force-application-device)~ (Didn't actually fix, I just forgot that I unsubscribed...)
[Aperture Science Handheld Portal Device](https://mod.io/g/bonelab/m/aperture-science-handheld-portal-device)
[Portals](https://mod.io/g/bonelab/m/bonelab-portals)
[Hang Glider](https://mod.io/g/bonelab/m/hang-glider)